### PR TITLE
Fix registration to return the user token on success

### DIFF
--- a/server/dbcon.py
+++ b/server/dbcon.py
@@ -25,7 +25,7 @@ def register(email, password):
     }
     try:
         _result = barry_db.users.insert_one(new_user)
-        return encode_auth_token(email).decode()
+        return encode_auth_token(email)
     except DuplicateKeyError:
         raise DuplicateKeyError("User already exists")
     except:


### PR DESCRIPTION
The registration route on the server was returning an error instead of the user's token despite being successful.
I fixed this by removing obsolete .encode() being called on a string (expecting the string to be a byte array).